### PR TITLE
Named injection for multiple database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,38 @@ class AppModule extends AbstractModule
         $this->install(new DbalModule('driver=pdo_sqlite&memory=true');
     }
 }
-
 ```
-### DI trait
 
- * [DbalInject](https://github.com/BEARSunday/BEAR.DbalModule/blob/master/src/DbalInject.php) for `Doctrine\DBAL\Driver\Connection` interface
+### for named binding
+
+Set `qualifer` in 2nd parameter in DbalModule.
+
+```php
+$this->install(new DbalModule('driver=pdo_sqlite&memory=true', 'log_db');
+```
+
+Use qualifer in `@Inject`.
+
+```php
+/**
+ * @Inject
+ * @Named("log_db")
+ */
+public function setLogDb(Connection $logDb)
+{
+    $this->logDb = $logDb;
+}
+```
+## DI trait
+
+ * [DbalInject](https://github.com/BEARSunday/BEAR.DbalModule/blob/1.x/src/DbalInject.php) for `Doctrine\DBAL\Driver\Connection` interface
  
-### Demo
+## Demo
 
     $ php docs/demo/run.php
     // It works!
 
-### Requiuments
+## Requiuments
 
  * PHP 5.4+
  * hhvm

--- a/src/DbalModule.php
+++ b/src/DbalModule.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Driver\Connection;
 use Ray\DbalModule\Annotation\DbalConfig;
 use Ray\Di\AbstractModule;
+use Ray\Di\Name;
 use Ray\Di\Scope;
 
 class DbalModule extends AbstractModule
@@ -20,11 +21,18 @@ class DbalModule extends AbstractModule
     private $config;
 
     /**
-     * @param string $config
+     * @var string
      */
-    public function __construct($config)
+    private $qualifier;
+
+    /**
+     * @param AbstractModule $config
+     * @param string         $qualifier
+     */
+    public function __construct($config, $qualifier = Name::ANY)
     {
         $this->config = $config;
+        $this->qualifier = $qualifier;
     }
 
     /**
@@ -33,7 +41,7 @@ class DbalModule extends AbstractModule
     protected function configure()
     {
         AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');
-        $this->bind()->annotatedWith(DbalConfig::class)->toInstance($this->config);
-        $this->bind(Connection::class)->toProvider(DbalProvider::class)->in(Scope::SINGLETON);
+        $this->bind()->annotatedWith($this->qualifier)->annotatedWith(DbalConfig::class)->toInstance($this->config);
+        $this->bind(Connection::class)->annotatedWith($this->qualifier)->toProvider(DbalProvider::class, $this->qualifier)->in(Scope::SINGLETON);
     }
 }

--- a/src/DbalProvider.php
+++ b/src/DbalProvider.php
@@ -8,22 +8,44 @@ namespace Ray\DbalModule;
 
 use Doctrine\DBAL\DriverManager;
 use Ray\DbalModule\Annotation\DbalConfig;
+use Ray\Di\Di\PostConstruct;
+use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
+use Ray\Di\SetContextInterface;
 
-class DbalProvider implements ProviderInterface
+class DbalProvider implements ProviderInterface, SetContextInterface
 {
+    /**
+     * @var InjectorInterface
+     */
+    private $injector;
+
+    /**
+     * @var string
+     */
+    private $context;
+
     /**
      * @var array
      */
     private $config;
 
-    /**
-     * @param string $config
-     *
-     * @DbalConfig
-     */
-    public function __construct($config)
+    public function __construct(InjectorInterface $injector)
     {
+        $this->injector = $injector;
+    }
+
+    public function setContext($context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @PostConstruct
+     */
+    public function init()
+    {
+        $config = $this->injector->getInstance('', DbalConfig::class . $this->context);
         if (is_array($config)) {
             $this->config = $config;
 
@@ -39,6 +61,7 @@ class DbalProvider implements ProviderInterface
 
         throw new \InvalidArgumentException('@DbalConfig');
     }
+
 
     /**
      * {@inheritdoc}

--- a/tests/DbalModuleTest.php
+++ b/tests/DbalModuleTest.php
@@ -12,4 +12,16 @@ class DbalModuleTest extends \PHPUnit_Framework_TestCase
         $instance = (new Injector(new DbalModule('driver=pdo_sqlite&memory=true'), $_ENV['TMP_DIR']))->getInstance(Connection::class);
         $this->assertInstanceOf(Connection::class, $instance);
     }
+
+    public function testQualifier()
+    {
+        $db1Module = new DbalModule('driver=pdo_sqlite&memory=true','db1');
+        $db2Module = new DbalModule('driver=pdo_sqlite&memory=true','db2');
+        $db1 = (new Injector($db1Module, $_ENV['TMP_DIR']))->getInstance(Connection::class, 'db1');
+        $db2 = (new Injector($db2Module, $_ENV['TMP_DIR']))->getInstance(Connection::class, 'db2');
+        $db1a = (new Injector($db1Module, $_ENV['TMP_DIR']))->getInstance(Connection::class, 'db1');
+        $this->assertInstanceOf(Connection::class, $db1);
+        $this->assertNotSame($db1, $db2);
+        $this->assertSame($db1, $db1a);
+    }
 }


### PR DESCRIPTION
For multiple database connection, Set `qualifer` in 2nd parameter in DbalModule.

```php
$this->install(new DbalModule('driver=pdo_sqlite&memory=true', 'log_db');
```

Use qualifer in `@Inject`.

```php
/**
 * @Inject
 * @Named("log_db")
 */
public function setLogDb(Connection $logDb)
{
    $this->logDb = $logDb;
}
```